### PR TITLE
SDS +CTSDSR flag order fix

### DIFF
--- a/sds/sds.go
+++ b/sds/sds.go
@@ -60,14 +60,22 @@ func ParseHeader(s string) (Header, error) {
 
 	var result Header
 	headerFields := strings.Split(s[8:], ",")
+	// field order according to ETSI TS 100 392-5 V2.6.1
+	// +CTSDSR: <AI service>, [<calling party identity>], [<calling party identity type>], <called party identity>, <called party identity type>, <length>, [<end to end encryption>]<CR><LF>user data	
 	switch len(headerFields) {
-	case 3, 4: // minimum set
+	case 3: // minimum set
 		result.AIService = AIService(strings.TrimSpace(headerFields[0]))
 		result.Destination = tetra.Identity(strings.TrimSpace(headerFields[1]))
+		pduBitCountField = headerFields[2]
+	case 4: // minimum set with identity type
+		result.AIService = AIService(strings.TrimSpace(headerFields[0]))
+		result.Destination = tetra.Identity(strings.TrimSpace(headerFields[1]))
+		pduBitCountField = headerFields[3]
 	case 6, 7: // with source, with end-to-end encryption
 		result.AIService = AIService(strings.TrimSpace(headerFields[0]))
 		result.Source = tetra.Identity(strings.TrimSpace(headerFields[1]))
 		result.Destination = tetra.Identity(strings.TrimSpace(headerFields[3]))
+		pduBitCountField = headerFields[5]
 	default:
 		return Header{}, fmt.Errorf("invalid header, wrong field count: %s", s)
 	}

--- a/sds/sds_test.go
+++ b/sds/sds_test.go
@@ -422,9 +422,11 @@ func TestParseHeader(t *testing.T) {
 				PDUBits:     16,
 			},
 		},
+		// field order according to ETSI TS 100 392-5 V2.6.1
+		// +CTSDSR: <AI service>, [<calling party identity>], [<calling party identity type>], <called party identity>, <called party identity type>, <length>, [<end to end encryption>]<CR><LF>user data
 		{
 			desc:  "valid with source identity and end-to-end encryption",
-			value: "+CTSDSR: 12,1234567,0,2345678,0,1,16",
+			value: "+CTSDSR: 12,1234567,0,2345678,0,16,1",
 			expected: Header{
 				AIService:   SDSTLService,
 				Source:      "1234567",


### PR DESCRIPTION
I noticed that a wrong length is parsed for SDS with the e2ee flag set. I checked ETSI TS 100 392-5 V2.6.1 and it defines a different order. I updated the test and then fixed the ParseHeader func to match the spec. This shouldn't break any other cases and all tests still pass.