### PR TITLE
fix double initialization of pduBitCountField

### DIFF
--- a/sds/sds.go
+++ b/sds/sds.go
@@ -81,7 +81,6 @@ func ParseHeader(s string) (Header, error) {
 		return Header{}, fmt.Errorf("invalid header, wrong field count: %s", s)
 	}
 
-	pduBitCountField := headerFields[len(headerFields)-1]
 	var err error
 	result.PDUBits, err = strconv.Atoi(strings.TrimSpace(pduBitCountField))
 	if err != nil {


### PR DESCRIPTION
I'm very sorry - merging my pieced together pull request #1 seemingly broke your master branch. I cherry-picked the earlier initialization line of pduBitCountField in 78cd0e4aac532741ed930c20b2c1b1352c955921 and forgot to remove the original init later in the func. This patch will fix that by removing the original initialization. Will try to stick to a simpler workflow with fewer commits in the future.