### PR TITLE
support simple callout service (paging)

### DIFF
--- a/sds/sds.go
+++ b/sds/sds.go
@@ -144,6 +144,7 @@ const (
 	ImmediateTextMessaging         ProtocolIdentifier = 0x89
 	UserDataHeaderMessaging        ProtocolIdentifier = 0x8A
 	ConcatenatedSDSMessaging       ProtocolIdentifier = 0x8C
+	Callout                        ProtocolIdentifier = 0xC3
 )
 
 /* SDS-TL related types and functions */
@@ -151,7 +152,8 @@ const (
 // ParseSDSTLPDU parses an SDS-TL PDU from the given bytes according to [AI] 29.4.1.
 // This function currently supports only a subset of the possible protocol identifiers:
 // Simple text messaging (0x02), simple immediate text messaging (0x09), text messaging (0x82),
-// immediate text messaging (0x89), message with user data header (0x8A)
+// immediate text messaging (0x89), message with user data header (0x8A),
+// concatenated SDS messaging (0x8C), and callout (0xC3).
 func ParseSDSTLPDU(bytes []byte) (interface{}, error) {
 	if len(bytes) == 0 {
 		return nil, fmt.Errorf("empty payload")
@@ -160,7 +162,7 @@ func ParseSDSTLPDU(bytes []byte) (interface{}, error) {
 	switch ProtocolIdentifier(bytes[0]) {
 	case SimpleTextMessaging, SimpleImmediateTextMessaging:
 		return ParseSimpleTextMessage(bytes)
-	case TextMessaging, ImmediateTextMessaging, UserDataHeaderMessaging:
+	case TextMessaging, ImmediateTextMessaging, UserDataHeaderMessaging, ConcatenatedSDSMessaging, Callout:
 		return parseSDSTLMessage(bytes)
 	default:
 		return nil, fmt.Errorf("protocol 0x%x not supported", bytes[0])
@@ -360,6 +362,10 @@ func ParseSDSTransfer(bytes []byte) (SDSTransfer, error) {
 		sdu, err = ParseTextSDU(bytes[userdataStart:])
 	case UserDataHeaderMessaging:
 		sdu, err = ParseConcatenatedTextSDU(bytes[userdataStart:])
+	case ConcatenatedSDSMessaging:
+		sdu, err = ParseConcatenatedSDSMessageSDU(bytes[userdataStart:])
+	case Callout:
+		sdu, err = ParseCalloutSDU(bytes[userdataStart:])
 	default:
 		return SDSTransfer{}, fmt.Errorf("protocol 0x%x is not supported as SDS-TRANSFER content", bytes[0])
 	}
@@ -1102,6 +1108,125 @@ const (
 	ConcatenatedTextMessageWithLongReference  UDHInformationElementID = 0x08
 )
 
+/* Concatenated SDS messaging related types and functions */
+
+func ParseConcatenatedSDSMessageSDU(bytes []byte) (ConcatenatedSDSMessageSDU, error) {
+	/*
+		Parses the structure of a Concatenated SDS message (PID 0x8C) :
+
+		1. Concatenation Control Header (4 bits)
+			Bits:   7   6   5  | 4 |  3   2   1   0
+				----------- --- ---------------
+				PDU Type     | Reference Extension Present
+
+			- PDU Type (bits 7–5): Must be 0b000 (Concatenation Transfer)
+			- Reference Extension Present (bit 4):
+				- 0 = only short reference used (4 bits total)
+				- 1 = extension present (12-bit reference total)
+
+			the next 4 bits (bits 3-0) will either be the upper 4 bits of the reference
+			(if extension is present) or the short reference (if extension is not present)
+
+		2. Concatenation Reference Extension (optional, 8 bits)
+			- Present only if Reference Extension Present == 1
+			- Contains the upper 8 bits of the 12-bit reference value
+
+		3. Short Reference (4 bits):
+			- Always present, even when extension is used
+			- Forms the lower 4 bits of the reference number
+
+		4. Total Number of Concatenation Parts (1 byte)
+			- Range: 2–255
+			- All parts of a single concatenated message share the same reference and total
+
+		5. Sequence Number of Current Part (1 byte)
+			- Range: 1–255
+			- Indicates the position of this fragment (1 = first)
+
+		6. Payload Protocol Identifier (optional, 1 byte)
+			- Present only if Sequence Number == 1
+			- Identifies the actual SDS PID of the original (unfragmented) message
+			- Not present in parts 2 and onward
+
+		7. Payload Data (remaining bytes)
+			- The actual SDS application payload fragment for this message part
+			- May be empty (e.g. padding or protocol artifacts)
+	*/
+
+	var result ConcatenatedSDSMessageSDU
+
+	offset := 0
+	if len(bytes) < offset+1 {
+		return result, fmt.Errorf("data too short for concatenation control header")
+	}
+
+	ctrlByte := bytes[offset]
+
+	// Extract the PDU type from bits 7–5 (should be 0b000 for "Concatenation Transfer")
+	pduType := (ctrlByte & 0xE0) >> 5
+	if pduType != 0b000 {
+		return result, fmt.Errorf("unsupported PDU type: %03b", pduType)
+	}
+
+	// Bit 4 indicates whether the reference extension is present
+	refType := (ctrlByte & 0x10) >> 4
+
+	offset++ // move past the control byte
+
+	if refType == 1 {
+		// Reference extension is present — need to read the next byte
+		if len(bytes) < offset+1 {
+			return result, fmt.Errorf("missing reference extension byte")
+		}
+
+		extByte := bytes[offset]
+		offset++
+
+		// Combine into 12-bit reference:
+		// ctrlByte bits 3-0 (upper 4 ext bits) go to positions 11-8
+		// extByte bits 7-0 (lower 4 ext bits + short ref) go to positions 7-0
+		result.ConcatenationReference = (uint16(ctrlByte&0x0F) << 8) | uint16(extByte)
+	} else {
+		// No extension — 4-bit reference only from bits 3-0 of control byte
+		result.ConcatenationReference = uint16(ctrlByte & 0x0F)
+	}
+
+	// TotalNumber and SequenceNumber
+	if len(bytes) < offset+2 {
+		return result, fmt.Errorf("missing total number or sequence number")
+	}
+	result.TotalNumber = bytes[offset]
+	offset++
+	result.SequenceNumber = bytes[offset]
+	offset++
+
+	if result.SequenceNumber == 1 {
+		if len(bytes) < offset+1 {
+			return result, fmt.Errorf("missing payload PID")
+		}
+		result.PayloadPID = ProtocolIdentifier(bytes[offset])
+		// needs to be included in first message payload to be available for later parsing
+		//offset++
+	}
+
+	// PayloadData
+	if offset > len(bytes) {
+		return result, fmt.Errorf("offset exceeds data length")
+	}
+	result.PayloadData = bytes[offset:]
+
+	return result, nil
+}
+
+// ConcatenatedSDSMessageSDU according to [AI] 29.5.14.12
+type ConcatenatedSDSMessageSDU struct {
+	ConcatenationReference uint16
+	TotalNumber            byte
+	SequenceNumber         byte
+	PayloadPID             ProtocolIdentifier
+	PayloadData            []byte
+}
+
 /* Status related types and functions */
 
 // ParseStatus from the given bytes.
@@ -1202,4 +1327,139 @@ func EncodeTimestampUTC(timestamp time.Time) []byte {
 	result[2] |= byte(utc.Minute()) & 0x3F
 
 	return result
+}
+
+/* Callout related types and functions */
+
+// Simple Callout Service as defined in TTR001-21 V2.1.1 (2014-11):
+// TETRA Interoperability Profile (TIP) Part 21: Callout
+func ParseCalloutSDU(bytes []byte) (CalloutAlert, error) {
+	/*
+		[TLV: 0x0D + packed callout number + priority]
+		               └─ Packed byte: [Length:4bits][CalloutMSB:4bits] + remaining bytes
+		[Sender Address: 2 bytes]
+		[Receiver Count: 1 byte]
+		[Receiver Addresses: 2 bytes each]
+		[Separator: 0xFF]
+		[Text: remaining bytes, ISO8859-1]
+	*/
+
+	if len(bytes) < 4 { // Minimum size: PID(2) + GroupControl(2)
+		return CalloutAlert{}, fmt.Errorf("callout alert PDU too short: %d bytes", len(bytes))
+	}
+
+	var result CalloutAlert
+	offset := 0
+
+	// Parse TLV fields
+	tlvLoop:
+	for offset < len(bytes) {
+		if offset >= len(bytes) {
+			break
+		}
+
+		// Check type field (8 bits = 1 byte)
+		typeField := bytes[offset]
+
+		switch typeField {
+		case 0x0D: // Callout Number follows
+			offset += 1 // Skip type field
+			if offset >= len(bytes) {
+				return CalloutAlert{}, fmt.Errorf("insufficient bytes for packed fields")
+			}
+
+			// Parse packed byte containing length (upper 4 bits) and first part of callout number (lower 4 bits)
+			packedByte := bytes[offset]
+			lengthInBytes := int(packedByte >> 4)
+
+			if offset + lengthInBytes >= len(bytes) {
+				return CalloutAlert{}, fmt.Errorf("insufficient bytes for callout number and priority")
+			}
+
+			// Convert the callout number bytes to a single integer
+			var calloutNumber uint32 = 0
+
+			// First byte: constructed from packed byte and next byte
+			firstByte := (packedByte & 0x0F) << 4 | (bytes[offset+1] >> 4)
+			calloutNumber = uint32(firstByte)
+
+			// Add remaining bytes (if any) to build the complete integer
+			for i := 1; i < lengthInBytes; i++ {
+				calloutNumber = (calloutNumber << 8) | uint32(bytes[offset+i+1])
+			}
+
+			result.CalloutNumber = calloutNumber
+
+			// Priority is in the lower 4 bits after the complete callout number
+			priorityByteOffset := offset + lengthInBytes
+			result.Priority = bytes[priorityByteOffset] & 0x0F
+
+			offset = priorityByteOffset + 1
+
+		default:
+			break tlvLoop // Not a known TLV type, assume we've reached the fixed fields
+		}
+	}
+
+	// Parse remaining fixed fields: SenderSubAddress + ReceiverSubAddrLen + ReceiverSubAddresses + Text
+	if offset+3 > len(bytes) { // SenderAddr(2) + RecvAddrLen(1)
+		return CalloutAlert{}, fmt.Errorf("insufficient bytes for fixed fields")
+	}
+
+	// Parse Sender Sub Address (2 bytes)
+	result.SenderSubAddress = uint16((uint32(bytes[offset]) << 8) | uint32(bytes[offset+1]))
+	offset += 2
+
+	// Parse Receiver Sub Address Length (1 byte) - number of bytes for receiver addresses
+	ReceiverSubAddrLen := uint8(bytes[offset])
+	offset += 1
+
+	// Calculate how many bytes the receiver sub-addresses take up
+	receiverSubAddrBytes := int(ReceiverSubAddrLen) // Direct byte count
+
+	if len(bytes) < offset+receiverSubAddrBytes {
+		return result, fmt.Errorf("callout alert PDU too short for receiver sub-addresses: %d bytes", len(bytes))
+	}
+
+	// Parse Receiver Sub Addresses (2 bytes each)
+	numAddresses := receiverSubAddrBytes / 2
+	result.ReceiverSubAddresses = make([]SubAddress, numAddresses)
+	for i := 0; i < numAddresses; i++ {
+		addrOffset := offset + (i * 2)
+		result.ReceiverSubAddresses[i] = SubAddress((uint16(bytes[addrOffset]) << 8) | uint16(bytes[addrOffset+1]))
+	}
+	offset += receiverSubAddrBytes
+
+	// Skip separator (1 byte - should be 0xFF) - we don't store it, just verify it's there
+	if len(bytes) < offset+1 {
+		return CalloutAlert{}, fmt.Errorf("callout alert PDU missing separator")
+	}
+	separator := bytes[offset]
+	if separator != 0xFF {
+		return CalloutAlert{}, fmt.Errorf("invalid separator: expected 0xFF, got 0x%02X", separator)
+	}
+	offset += 1
+
+	// Parse Text (rest of the message)
+	if offset < len(bytes) {
+		// For simple callout messages, encoding is fixed to Latin-1
+		text, err := DecodePayloadText(ISO8859_1, bytes[offset:])
+		if err != nil {
+			return CalloutAlert{}, fmt.Errorf("failed to decode callout text: %w", err)
+		}
+		result.Text = text
+	}
+
+	return result, nil
+}
+
+type SubAddress uint16
+
+// CalloutAlert represents a callout alert PDU (PID 0xC3) for paging sub-addresses with text display
+type CalloutAlert struct {
+	CalloutNumber        uint32
+	Priority             uint8
+	SenderSubAddress     uint16
+	ReceiverSubAddresses []SubAddress
+	Text                 string
 }

--- a/sds/sds_test.go
+++ b/sds/sds_test.go
@@ -261,6 +261,68 @@ func TestParseMessage(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc:   "callout alert (simple callout), no report, no store/forward",
+			header: "+CTSDSR: 12,262100101234567,1,262100102345678,1,824,1",
+			pdu:    "C300110D1657111104144C155DFF54657374FE0A5465737454657374546573745465737454657374546573745465737454657374546573740A5465737454657374546573740A546573745465737454657374546573745465737454657374546573740A54657374",
+			expected: IncomingMessage{
+				Header: Header{AIService: SDSTLService, Source: "262100101234567", Destination: "262100102345678", PDUBits: 824},
+				Payload: SDSTransfer{
+					protocol:                        Callout,
+					ServiceSelectionShortFormReport: true,
+					MessageReference:                0x11,
+					UserData: CalloutAlert{
+						CalloutNumber: 				 0x65,
+						Priority:                    0x7,
+						SenderSubAddress:            0x1111,
+						ReceiverSubAddresses: []SubAddress{
+							0x144C,
+							0x155D,
+						},
+						Text: "Testþ\nTestTestTestTestTestTestTestTestTest\nTestTestTest\nTestTestTestTestTestTestTest\nTest",
+					},
+				},
+			},
+		},
+		{
+			desc:   "concatenated callout alert (simple callout) part 1 of 2, no report, no store/forward",
+			header: "+CTSDSR: 12,262100101234567,1,262100102345678,1,896,1",
+			pdu:    "8C00B910030201C30D196711111C000B000C000D000E13BC13BD13ED13F013F113F413F6141914231466FF54657374FE0A5465737454657374546573745465737454657374546573745465737454657374546573740A5465737454657374546573740A54657374546573745465737454",
+			expected: IncomingMessage{
+				Header: Header{AIService: SDSTLService, Source: "262100101234567", Destination: "262100102345678", PDUBits: 896},
+				Payload: SDSTransfer{
+					protocol:                        ConcatenatedSDSMessaging,
+					ServiceSelectionShortFormReport: true,
+					MessageReference:                0xB9,
+					UserData: ConcatenatedSDSMessageSDU{
+						ConcatenationReference: 3,
+						TotalNumber:    2,
+						SequenceNumber: 1,
+						PayloadPID: Callout,
+						PayloadData: []byte{0xc3, 0xd, 0x19, 0x67, 0x11, 0x11, 0x1c, 0x0, 0xb, 0x0, 0xc, 0x0, 0xd, 0x0, 0xe, 0x13, 0xbc, 0x13, 0xbd, 0x13, 0xed, 0x13, 0xf0, 0x13, 0xf1, 0x13, 0xf4, 0x13, 0xf6, 0x14, 0x19, 0x14, 0x23, 0x14, 0x66, 0xff, 0x54, 0x65, 0x73, 0x74, 0xfe, 0xa, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0xa, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0xa, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54},
+					},
+				},
+			},
+		},
+		{
+			desc:   "concatenated callout alert (simple callout) part 2 of 2, no report, no store/forward",
+			header: "+CTSDSR: 12,262100101234567,1,262100102345678,1,208,1",
+			pdu:    "8C00BA100302026573745465737454657374546573740A546573",
+			expected: IncomingMessage{
+				Header: Header{AIService: SDSTLService, Source: "262100101234567", Destination: "262100102345678", PDUBits: 208},
+				Payload: SDSTransfer{
+					protocol:                        ConcatenatedSDSMessaging,
+					ServiceSelectionShortFormReport: true,
+					MessageReference:                0xBA,
+					UserData: ConcatenatedSDSMessageSDU{
+						ConcatenationReference: 3,
+						TotalNumber:    2,
+						SequenceNumber: 2,
+						PayloadData: []byte{0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0x54, 0x65, 0x73, 0x74, 0xa, 0x54, 0x65, 0x73},
+					},
+				},
+			},
+		},
 	}
 	type immediater interface {
 		Immediate() bool
@@ -432,6 +494,16 @@ func TestParseHeader(t *testing.T) {
 				Source:      "1234567",
 				Destination: "2345678",
 				PDUBits:     16,
+			},
+		},
+		{
+			desc:  "valid SDS-TL message (type 4) with source TSI, destination TSI and end-to-end encryption",
+			value: "+CTSDSR: 12,262100101234567,1,262100102345678,1,808,1",
+			expected: Header{
+				AIService:   SDSTLService,
+				Source:      "262100101234567",
+				Destination: "262100102345678",
+				PDUBits:     808,
 			},
 		},
 	}


### PR DESCRIPTION
This pull request adds the bare minimum to be able to receive/decode callout SDS messages (PID 0xC3), both single and concatenated (using the previously not implemented PID 0x8C). The stack now also supports stacking multi-part SDS with PID 0x8C.

General notes:
- I tried to re-use and stick to existing conventions as much as possible. No existing functionality was dropped or changed, so this should not introduce breaking changes for any users
- I did not create any functionality for constructing / sending callout messages since I can't test this
- Tests are included to demonstrate the data structure and functionality
- Pull request contains the full set of changes I made (this time for real) and all tests pass

Notes regarding stack:
- Using the stack with 0x8C concatenation was quite frustrating. I didn't want to introduce changes to the Message or part structs, so I made it work for callout with binary to string conversion, but I feel that this is room for future improvement
- To be able to use the stack, I had to keep the PID of the user payload message in the user data even though it's a separate information element according to the spec [sds.go line 1209](https://github.com/ftl/tetra-pei/compare/master...reacu:tetra-pei:master#diff-f3cd83fad8f2a3df0c529bc397700c626d670b566d6e1a6ffb0fc5a52bdd6410R1209)
- Using the stack with SDSTransfer loses nearly all of the original metadata including protocols/types (because of how Message and part structs are designed) - this makes re-constructing a valid data structure for the next application layer very hard
- I feel that it would be beneficial to first stack up the full original objects including headers and only boil down the needed information when interacting with a completed message
- Maybe you have thoughts on how the stack could be improved without breaking everything